### PR TITLE
Update rollup.config.js

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import pkg from './package.json';
 
 export default {
   input: 'src/index.ts',
-  external: ['react', 'react-native', 'redux', 'react-redux', 'redux-saga'],
+  external: ['react', 'react-native', 'redux', 'react-redux', 'redux-saga', '@react-native-community/netinfo],
   plugins: [resolve(), commonjs(), typescript()],
   output: [
     { file: pkg.main, format: 'cjs' },


### PR DESCRIPTION
Add @react-native-community/netinfo to list of externals so that downstream packagers can chose to load with web or native versions of netinfo. Currently, this module only works on native because it packages @react-native-community/netinfo with the distribution.

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

## Test plan

Demonstrate the code is solid and make sure you add tests to cover the new functionality.

The code must pass tests.

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.
